### PR TITLE
Optimized the Window class

### DIFF
--- a/Subtitle-Display-Tool/src/Window.cpp
+++ b/Subtitle-Display-Tool/src/Window.cpp
@@ -9,6 +9,7 @@ Window::Window(std::string dialogue) : Window(Subtitle{dialogue}) {}
 
 Window::Window(Subtitle subtitle) : m_subtitle(subtitle), m_target(LoadRenderTexture(GetWindowDimensions().x, GetWindowDimensions().y))
 {
+	std::cout << "Constructor called" << std::endl;
 	BeginTextureMode(m_target);
 	Color fontColor = { m_subtitle.GetColor().x, m_subtitle.GetColor().y, m_subtitle.GetColor().z, 255 };
 	Color bgColor = { m_subtitle.GetBackgroundColor().x, m_subtitle.GetBackgroundColor().y, m_subtitle.GetBackgroundColor().z, m_subtitle.GetBackgroundColor().w };
@@ -17,10 +18,46 @@ Window::Window(Subtitle subtitle) : m_subtitle(subtitle), m_target(LoadRenderTex
 	EndTextureMode();
 }
 
+Window::Window(const Window& other): Window(other.m_subtitle)
+{
+	std::cout << "Copy constructor called" << std::endl;
+}
+
+//If we copy a temporary over, we don't want the texture to be unloaded when the temporary is destroyed.
+// So, remove the temporary's render target.
+Window::Window(Window&& other) noexcept : m_subtitle(other.m_subtitle), m_target(other.m_target)
+{
+	std::cout << "Move Constructor Called" << std::endl;
+	//BeginTextureMode(m_target);
+	//Color fontColor = { m_subtitle.GetColor().x, m_subtitle.GetColor().y, m_subtitle.GetColor().z, 255 };
+	//Color bgColor = { m_subtitle.GetBackgroundColor().x, m_subtitle.GetBackgroundColor().y, m_subtitle.GetBackgroundColor().z, m_subtitle.GetBackgroundColor().w };
+	//ClearBackground(bgColor);
+	//DrawTextEx(m_subtitle.GetFont(), m_subtitle.GetDialogue().c_str(), { 0, 0 }, m_subtitle.GetFontSize(), DEFAULT_SPACING, WHITE);
+	//EndTextureMode();
+	other.m_target = {};
+}
+
+Window& Window::operator=(const Window& other)
+{
+	std::cout << "Assignment operator - shouldn't be called" << std::endl;
+	throw std::exception();
+	// TODO: insert return statement here
+	return *this = Window(other);
+}
+
+Window& Window::operator=(Window&& other) noexcept
+{
+	std::cout << "Move assignment operator - shouldn't be called" << std::endl;
+	throw std::exception();
+	// TODO: insert return statement here
+	return *this;
+}
+
 //Textures need to be cleaned up from GPU memory, but texture id's currently are shared between copies when Window objects are passed around. Need to define copy/move constructors
 //to prevent sharing of texture ids. Current solution: just don't clean up.
 Window::~Window() {
-	//UnloadTexture(m_target.texture);
+	std::cout << "Destructor called" << std::endl;
+	UnloadTexture(m_target.texture);
 }
 
 Vec2f Window::GetWindowDimensions() const

--- a/Subtitle-Display-Tool/src/Window.h
+++ b/Subtitle-Display-Tool/src/Window.h
@@ -6,6 +6,10 @@ class Window {
 public:
 	Window(std::string dialogue);
 	Window(Subtitle subtitle);
+	Window(const Window& other);
+	Window(Window&& other) noexcept;
+	Window& operator=(const Window& other);
+	Window& operator=(Window&& other) noexcept;
 	~Window();
 	Vec2f GetWindowDimensions() const;
 	void Draw() const;

--- a/Subtitle-Display-Tool/src/WindowManager.cpp
+++ b/Subtitle-Display-Tool/src/WindowManager.cpp
@@ -5,6 +5,11 @@ void WindowManager::AddWindow(const Window& window)
 	m_windows.push_back(window);
 }
 
+void WindowManager::AddWindow(Window&& window)
+{
+	m_windows.push_back(std::move(window));
+}
+
 void WindowManager::DrawWindows()
 {
 	for (const auto& window : m_windows) {

--- a/Subtitle-Display-Tool/src/WindowManager.h
+++ b/Subtitle-Display-Tool/src/WindowManager.h
@@ -5,6 +5,7 @@
 class WindowManager {
 public:
 	void AddWindow(const Window& window);
+	void AddWindow(Window&& window);
 	void DrawWindows();
 private:
 	std::vector<Window> m_windows;


### PR DESCRIPTION
Window class used to not be able to free its textures upon destruction because the texture ID was shared between copies. Created copy and move constructors to make sure that no texture is shared between two Window instances. If moved, the moved Window will have its m_target member reset. If copied, the new instance will generate a new texture and re-render the text.